### PR TITLE
Travis uses Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: r
-dist: bionic
+# dist: bionic # Uncomment until fix of https://travis-ci.community/t/r-install-broken-travis-ci-rstudio-org-returns-403/9640
 cache: packages
 compiler: clang
 


### PR DESCRIPTION
Fixed [your build error](https://travis-ci.org/github/thijsjanzen/GenomeAdmixR/jobs/719587831#L635)

Uncomment until fix of https://travis-ci.community/t/r-install-broken-travis-ci-rstudio-org-returns-403/9640